### PR TITLE
Feat/harbor

### DIFF
--- a/infrastructure/ephemeral-resources/eks-control-plane.tf
+++ b/infrastructure/ephemeral-resources/eks-control-plane.tf
@@ -56,6 +56,15 @@ resource "aws_eks_addon" "example" {
   resolve_conflicts_on_update = "PRESERVE"
 }
 
+# https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+# Manages the lifecycle of Amazon EBS volumes as storage for the Kubernetes Volumes
+resource "aws_eks_addon" "aws-ebs-csi-driver" {
+  cluster_name                = aws_eks_cluster.eks.name
+  addon_name                  = "aws-ebs-csi-driver"
+  resolve_conflicts_on_update = "PRESERVE"
+  service_account_role_arn    = aws_iam_role.AmazonEKS_EBS_CSI_DriverRole.arn
+}
+
 # Cluster outputs
 output "endpoint" {
   value = aws_eks_cluster.eks.endpoint

--- a/infrastructure/ephemeral-resources/oidc.tf
+++ b/infrastructure/ephemeral-resources/oidc.tf
@@ -1,0 +1,15 @@
+########### EKS Cluster IdP - Required to allow k8s serviceaccounts to assume IAM Roles ##############
+# https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+
+# Get information about the TLS certificate that protects the OIDC issuer URL embedded on every EKS clusters
+# https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate
+data "tls_certificate" "eks" {
+  url = aws_eks_cluster.eks.identity[0].oidc[0].issuer
+}
+
+# Create an Identity Provider on AWS and trust on it (in this case, the embedded IdP of our eks cluster)
+resource "aws_iam_openid_connect_provider" "eks-idp" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.eks.identity[0].oidc[0].issuer
+}


### PR DESCRIPTION
- we'll need to change the instance type, even with t3.micro 12 workers node there is not enough RAM to deploy harbor.
- Harbor creates Statefulsets with PVCs. We need aws-ebs-csi-driver add-on in place 